### PR TITLE
Fix go modules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/ip2location/ip2proxy-go
+module github.com/ip2location/ip2proxy-go/v3
 
 go 1.14


### PR DESCRIPTION
```
go get github.com/ip2location/ip2proxy-go@v3.3.1
go get: github.com/ip2location/ip2proxy-go@v3.3.1: invalid version: module contains a go.mod file, so major version must be compatible: should be v0 or v1, not v3
```

@ip2location 
New releases are unusable now.

https://golang.org/ref/mod#major-version-suffixes